### PR TITLE
Don't add meta block for certain formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,12 @@ exports.register = function (server, options, next) {
   var content = options.content || {credit: 'response-meta'};
   var results = options.results || 'results';
   var routes = options.routes || ['*'];
+  var excludeFormats = options.excludeFormats || [];
 
   server.ext('onPreResponse', function (request, reply) {
-    if (routes.indexOf(request.route.path) !== -1 || routes[0] === '*') {
+    // Make sure route matches and we're not exclude based on format
+    if ((routes.indexOf(request.route.path) !== -1 || routes[0] === '*') &&
+      excludeFormats.indexOf(request.query.format) === -1) {
       if (_.has(request.response.source, name)) {
 
         request.response.source[name] = _.merge(request.response.source[name], content);

--- a/test/test.js
+++ b/test/test.js
@@ -163,4 +163,27 @@ describe('Test hapi-response-meta', function () {
       );
     });
   });
+
+  it('test exclude option', function (done) {
+    var server = register();
+    var plugin = {
+      register: require('../'),
+      options: {
+        content: {
+          license: 'Some license',
+          website: 'example.com'
+        },
+        excludeFormats: ['csv']
+      }
+    };
+    server.register(plugin, function (err) {
+      expect(err).to.be.empty;
+
+      var request = { method: 'GET', url: '/?format=csv'};
+      server.inject(request, function (res) {
+        expect(res.result).to.equal('ok');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
For example, when using csv, we wouldn't want meta block included.
